### PR TITLE
Add meta storage options to S3 data lake

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteTypeToAirbyteTypeWithMeta.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteTypeToAirbyteTypeWithMeta.kt
@@ -7,7 +7,11 @@ package io.airbyte.cdk.load.data
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.message.Meta.AirbyteMetaFields
 
-class AirbyteTypeToAirbyteTypeWithMeta(private val flatten: Boolean) {
+class AirbyteTypeToAirbyteTypeWithMeta(
+    private val flatten: Boolean,
+    private val metaStorage: MetaStorage,
+    private val metaNullable: Boolean,
+) {
     fun convert(schema: AirbyteType): ObjectType {
         val properties =
             linkedMapOf(
@@ -16,7 +20,10 @@ class AirbyteTypeToAirbyteTypeWithMeta(private val flatten: Boolean) {
                 Meta.COLUMN_NAME_AB_EXTRACTED_AT to
                     FieldType(AirbyteMetaFields.EXTRACTED_AT.type, nullable = false),
                 Meta.COLUMN_NAME_AB_META to
-                    FieldType(AirbyteMetaFields.META.type, nullable = false),
+                    FieldType(
+                        if (metaStorage == MetaStorage.STRING) StringType else AirbyteMetaFields.META.type,
+                        nullable = metaNullable,
+                    ),
                 Meta.COLUMN_NAME_AB_GENERATION_ID to
                     FieldType(AirbyteMetaFields.GENERATION_ID.type, nullable = false),
             )
@@ -37,5 +44,9 @@ class AirbyteTypeToAirbyteTypeWithMeta(private val flatten: Boolean) {
     }
 }
 
-fun AirbyteType.withAirbyteMeta(flatten: Boolean = false): ObjectType =
-    AirbyteTypeToAirbyteTypeWithMeta(flatten).convert(this)
+fun AirbyteType.withAirbyteMeta(
+    flatten: Boolean = false,
+    metaStorage: MetaStorage = MetaStorage.OBJECT,
+    metaNullable: Boolean = false,
+): ObjectType =
+    AirbyteTypeToAirbyteTypeWithMeta(flatten, metaStorage, metaNullable).convert(this)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MetaStorage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MetaStorage.kt
@@ -1,0 +1,3 @@
+package io.airbyte.cdk.load.data
+
+enum class MetaStorage { OBJECT, STRING }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteTypeToAirbyteTypeWithMetaTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteTypeToAirbyteTypeWithMetaTest.kt
@@ -75,4 +75,24 @@ internal class AirbyteTypeToAirbyteTypeWithMetaTest {
         schema.properties.forEach { (name, field) -> expected.properties[name] = field }
         assertEquals(expected, withMeta)
     }
+
+    @Test
+    fun testStringMetaNullable() {
+        val schema = ObjectType(emptyMap())
+        val withMeta = schema.withAirbyteMeta(
+            flatten = true,
+            metaStorage = MetaStorage.STRING,
+            metaNullable = true,
+        )
+        val expected =
+            ObjectType(
+                linkedMapOf(
+                    Meta.COLUMN_NAME_AB_RAW_ID to FieldType(StringType, nullable = false),
+                    Meta.COLUMN_NAME_AB_EXTRACTED_AT to FieldType(IntegerType, nullable = false),
+                    Meta.COLUMN_NAME_AB_META to FieldType(StringType, nullable = true),
+                    Meta.COLUMN_NAME_AB_GENERATION_ID to FieldType(IntegerType, nullable = false),
+                )
+            )
+        assertEquals(expected, withMeta)
+    }
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
@@ -22,6 +22,7 @@ import io.airbyte.cdk.load.data.NumberValue
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.MetaStorage
 import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.data.UnknownType
@@ -230,13 +231,23 @@ class IcebergUtil(private val tableIdGenerator: TableIdGenerator) {
         }
     }
 
-    fun toIcebergSchema(stream: DestinationStream): Schema {
+    fun toIcebergSchema(
+        stream: DestinationStream,
+        metaStorageString: Boolean = false,
+        metaNullable: Boolean = false,
+    ): Schema {
         val primaryKeys =
             when (stream.importType) {
                 is Dedupe -> (stream.importType as Dedupe).primaryKey
                 else -> emptyList()
             }
-        return stream.schema.withAirbyteMeta(true).toIcebergSchema(primaryKeys)
+        return stream.schema
+            .withAirbyteMeta(
+                flatten = true,
+                metaStorage = if (metaStorageString) MetaStorage.STRING else MetaStorage.OBJECT,
+                metaNullable = metaNullable,
+            )
+            .toIcebergSchema(primaryKeys)
     }
 
     private fun getSortOrder(schema: Schema): SortOrder {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToAvroFormatter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToAvroFormatter.kt
@@ -51,12 +51,18 @@ class ProtoToAvroFormatter(
     outputStream: OutputStream,
     formatConfig: AvroFormatConfiguration,
     private val rootLevelFlattening: Boolean,
+    private val metaStorageString: Boolean = false,
+    private val metaNullable: Boolean = false,
 ) : ObjectStorageFormattingWriter {
     private val longMin = Long.MIN_VALUE.toBigInteger()
     private val longMax = Long.MAX_VALUE.toBigInteger()
 
     private val logicalSchema: ObjectType =
-        mergeUnions(stream.schema).withAirbyteMeta(rootLevelFlattening)
+        mergeUnions(stream.schema).withAirbyteMeta(
+            rootLevelFlattening,
+            metaStorage = if (metaStorageString) MetaStorage.STRING else MetaStorage.OBJECT,
+            metaNullable = metaNullable,
+        )
     private val avroSchema: Schema = logicalSchema.toAvroSchema(stream.mappedDescriptor)
     private val writer =
         outputStream.toAvroWriter(avroSchema, formatConfig.avroCompressionConfiguration)
@@ -65,8 +71,8 @@ class ProtoToAvroFormatter(
 
     // meta
     private val metaSchema = avroSchema.nonNullSubSchemaOf(safe(Meta.COLUMN_NAME_AB_META))
-    private val changeArraySchema = metaSchema.getField("changes").schema().nonNullOrSelf()
-    private val changeRecordSchema = changeArraySchema.elementType.nonNullOrSelf()
+    private val changeArraySchema = metaSchema.takeIf { it.type == Schema.Type.RECORD }?.getField("changes")?.schema()?.nonNullOrSelf()
+    private val changeRecordSchema = changeArraySchema?.elementType?.nonNullOrSelf()
 
     // column table
     private data class ColumnWriter(
@@ -438,13 +444,17 @@ class ProtoToAvroFormatter(
         return null
     }
 
-    private fun buildMeta(syncId: Long, changes: List<Meta.Change>): GenericRecord {
+    private fun buildMeta(syncId: Long, changes: List<Meta.Change>): Any? {
+        if (metaStorageString) {
+            if (metaNullable && changes.isEmpty()) return null
+            return buildMetaString(syncId, changes)
+        }
         val meta = GenericData.Record(metaSchema)
         meta.put("sync_id", syncId)
 
-        val array = GenericData.Array<GenericRecord>(changes.size, changeArraySchema)
+        val array = GenericData.Array<GenericRecord>(changes.size, changeArraySchema!!)
         changes.forEach { c ->
-            val rec = GenericData.Record(changeRecordSchema)
+            val rec = GenericData.Record(changeRecordSchema!!)
             rec.put("field", c.field)
             rec.put("change", c.change.name)
             rec.put("reason", c.reason.name)
@@ -453,6 +463,21 @@ class ProtoToAvroFormatter(
         meta.put("changes", array)
         return meta
     }
+
+    private fun buildMetaString(syncId: Long, changes: List<Meta.Change>): String =
+        buildString(64) {
+            append('{')
+            append("\"sync_id\":").append(syncId).append(',')
+            append("\"changes\":[")
+            changes.forEachIndexed { idx, c ->
+                append('{')
+                append("\"field\":\"").append(c.field).append("\",")
+                append("\"change\":\"").append(c.change.name).append("\",")
+                append("\"reason\":\"").append(c.reason.name).append("\"}")
+                if (idx != changes.lastIndex) append(',')
+            }
+            append("]}")
+        }
 
     private fun matchingAvroType(airbyteSchema: AirbyteType, avroUnion: Schema): Schema? =
         when (airbyteSchema) {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonFormatter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonFormatter.kt
@@ -17,11 +17,18 @@ import java.io.OutputStream
 class ProtoToJsonFormatter(
     stream: DestinationStream,
     private val outputStream: OutputStream,
-    rootLevelFlattening: Boolean
+    rootLevelFlattening: Boolean,
+    metaStorageString: Boolean = false,
+    metaNullable: Boolean = false,
 ) : ObjectStorageFormattingWriter {
 
     private val fastWriter =
-        ProtoToJsonWriter(stream.airbyteValueProxyFieldAccessors, rootLevelFlattening)
+        ProtoToJsonWriter(
+            stream.airbyteValueProxyFieldAccessors,
+            rootLevelFlattening,
+            metaStorageString,
+            metaNullable,
+        )
     private val unknownColumnChanges =
         stream.schema.collectUnknownPaths().map {
             Meta.Change(

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonWriter.kt
@@ -18,7 +18,9 @@ import java.math.BigInteger
 
 class ProtoToJsonWriter(
     private val columns: Array<AirbyteValueProxy.FieldAccessor>,
-    private val flatten: Boolean
+    private val flatten: Boolean,
+    private val metaStorageString: Boolean = false,
+    private val metaNullable: Boolean = false,
 ) {
 
     fun writeMeta(gen: JsonGenerator, record: DestinationRecordRaw, changes: List<Meta.Change>) =
@@ -26,24 +28,43 @@ class ProtoToJsonWriter(
             writeStringField(COLUMN_NAME_AB_RAW_ID, record.airbyteRawId.toString())
             writeNumberField(COLUMN_NAME_AB_EXTRACTED_AT, record.rawData.emittedAtMs)
 
-            // _airbyte_meta
-            writeFieldName(COLUMN_NAME_AB_META)
-            writeStartObject()
-            writeNumberField("sync_id", record.stream.syncId)
-
-            writeFieldName("changes")
-            writeStartArray()
-            for (c in changes) {
+            if (metaStorageString) {
+                if (metaNullable && changes.isEmpty()) writeNullField(COLUMN_NAME_AB_META)
+                else writeStringField(COLUMN_NAME_AB_META, buildMetaString(record.stream.syncId, changes))
+            } else {
+                writeFieldName(COLUMN_NAME_AB_META)
                 writeStartObject()
-                writeStringField("field", c.field)
-                writeStringField("change", c.change.name)
-                writeStringField("reason", c.reason.name)
-                writeEndObject()
+                writeNumberField("sync_id", record.stream.syncId)
+
+                writeFieldName("changes")
+                writeStartArray()
+                for (c in changes) {
+                    writeStartObject()
+                    writeStringField("field", c.field)
+                    writeStringField("change", c.change.name)
+                    writeStringField("reason", c.reason.name)
+                    writeEndObject()
+                }
+                writeEndArray()
+                writeEndObject() // _airbyte_meta
             }
-            writeEndArray()
-            writeEndObject() // _airbyte_meta
 
             writeNumberField(COLUMN_NAME_AB_GENERATION_ID, record.stream.generationId)
+        }
+
+    private fun buildMetaString(syncId: Long, changes: List<Meta.Change>): String =
+        buildString(64) {
+            append('{')
+            append("\"sync_id\":").append(syncId).append(',')
+            append("\"changes\":[")
+            changes.forEachIndexed { idx, c ->
+                append('{')
+                append("\"field\":\"").append(c.field).append("\",")
+                append("\"change\":\"").append(c.change.name).append("\",")
+                append("\"reason\":\"").append(c.reason.name).append("\"}")
+                if (idx != changes.lastIndex) append(',')
+            }
+            append("]}")
         }
 
     fun writePayload(gen: JsonGenerator, src: DestinationRecordProtobufSource) {

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeConfiguration.kt
@@ -24,6 +24,8 @@ data class S3DataLakeConfiguration(
     override val awsAccessKeyConfiguration: AWSAccessKeyConfiguration,
     override val s3BucketConfiguration: S3BucketConfiguration,
     override val icebergCatalogConfiguration: IcebergCatalogConfiguration,
+    val metaStorage: S3DataLakeSpecification.MetaStorage = S3DataLakeSpecification.MetaStorage.OBJECT,
+    val metaNullable: Boolean = false,
     // Now that partitioning is enabled, we can run more than one worker.
     // This will likely not show performance improvements in the cloud without additional
     // resources. In the future, if enterprise or oss users need more flexibility, we can
@@ -46,6 +48,8 @@ class S3DataLakeConfigurationFactory :
             awsAccessKeyConfiguration = pojo.toAWSAccessKeyConfiguration(),
             s3BucketConfiguration = pojo.toS3BucketConfiguration(),
             icebergCatalogConfiguration = pojo.toIcebergCatalogConfiguration(),
+            metaStorage = pojo.metaStorage,
+            metaNullable = pojo.metaNullable,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeSpecification.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import com.fasterxml.jackson.annotation.JsonValue
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.aws.AWSAccessKeySpecification
 import io.airbyte.cdk.load.command.iceberg.parquet.CatalogType
@@ -71,6 +72,21 @@ class S3DataLakeSpecification :
 
     @get:JsonSchemaInject(json = """{"always_show": true,"order":7}""")
     override val catalogType: CatalogType = GlueCatalogSpecification(glueId = "", databaseName = "")
+
+    enum class MetaStorage(@get:JsonValue val value: String) {
+        OBJECT("object"),
+        STRING("string"),
+    }
+
+    @get:JsonSchemaTitle("_airbyte_meta Storage")
+    @get:JsonPropertyDescription("Store the _airbyte_meta column as an object or a JSON string.")
+    @get:JsonSchemaInject(json = """{"order":8,"default":"object"}""")
+    val metaStorage: MetaStorage = MetaStorage.OBJECT
+
+    @get:JsonSchemaTitle("Nullable _airbyte_meta")
+    @get:JsonPropertyDescription("Allow null values in the _airbyte_meta column.")
+    @get:JsonSchemaInject(json = """{"order":9,"default":false}""")
+    val metaNullable: Boolean = false
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
@@ -14,6 +14,7 @@ import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
 import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.integrations.destination.s3_data_lake.io.S3DataLakeUtil
+import io.airbyte.integrations.destination.s3_data_lake.S3DataLakeSpecification
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
@@ -42,7 +43,12 @@ class S3DataLakeStreamLoader(
         } else {
             ColumnTypeChangeBehavior.SAFE_SUPERTYPE
         }
-    private val incomingSchema = icebergUtil.toIcebergSchema(stream = stream)
+    private val incomingSchema =
+        icebergUtil.toIcebergSchema(
+            stream = stream,
+            metaStorageString = icebergConfiguration.metaStorage == S3DataLakeSpecification.MetaStorage.STRING,
+            metaNullable = icebergConfiguration.metaNullable,
+        )
 
     @SuppressFBWarnings(
         "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoaderTest.kt
@@ -149,7 +149,7 @@ internal class S3DataLakeStreamLoaderTest {
         val icebergUtil: IcebergUtil = mockk {
             every { createCatalog(any(), any()) } returns catalog
             every { createTable(any(), any(), any(), any()) } returns table
-            every { toIcebergSchema(any()) } answers
+            every { toIcebergSchema(any(), any(), any()) } answers
                 {
                     stream.schema.withAirbyteMeta(true).toIcebergSchema(emptyList())
                 }
@@ -249,7 +249,7 @@ internal class S3DataLakeStreamLoaderTest {
         val icebergUtil: IcebergUtil = mockk {
             every { createCatalog(any(), any()) } returns catalog
             every { createTable(any(), any(), any(), any()) } returns table
-            every { toIcebergSchema(any()) } answers
+            every { toIcebergSchema(any(), any(), any()) } answers
                 {
                     stream.schema.withAirbyteMeta(true).toIcebergSchema(emptyList())
                 }
@@ -402,7 +402,7 @@ internal class S3DataLakeStreamLoaderTest {
         val icebergUtil: IcebergUtil = mockk {
             every { createCatalog(any(), any()) } returns catalog
             every { createTable(any(), any(), any(), any()) } returns table
-            every { toIcebergSchema(any()) } answers
+            every { toIcebergSchema(any(), any(), any()) } answers
                 {
                     stream.schema.withAirbyteMeta(true).toIcebergSchema(listOf(primaryKeys))
                 }
@@ -461,7 +461,7 @@ internal class S3DataLakeStreamLoaderTest {
         val icebergConfiguration: S3DataLakeConfiguration = mockk()
         val s3DataLakeUtil: S3DataLakeUtil = mockk()
         val icebergUtil: IcebergUtil = mockk {
-            every { toIcebergSchema(any()) } answers
+            every { toIcebergSchema(any(), any(), any()) } answers
                 {
                     stream.schema.withAirbyteMeta(true).toIcebergSchema(emptyList())
                 }

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -15,6 +15,8 @@ The S3 Data Lake connector requires two things.
     - AWS Glue
     - Nessie
 
+The destination exposes advanced options to control how the `_airbyte_meta` column is stored. Set `meta_storage` to `"string"` to store the metadata as a JSON string instead of an object, and `meta_nullable` to `true` to allow null values.
+
 ## Setup guide
 
 Follow these steps to set up your S3 storage and Iceberg catalog permissions.


### PR DESCRIPTION
## Summary
- allow `_airbyte_meta` column to be stored as string or object
- propagate meta settings through configuration into schema generation
- update object storage writers to handle stringified metadata
- test new behaviour and document configuration

## Testing
- `./gradlew :airbyte-cdk:bulk:core:load:test :airbyte-cdk:bulk:toolkits:load-object-storage:test :airbyte-cdk:bulk:toolkits:load-iceberg-parquet:test :airbyte-integrations:connectors:destination-s3-data-lake:test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_687a8d1eb5508323be7898642d9c3641